### PR TITLE
[RELEASE] Compose/1.8.1

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "451a4227a52c5d76284cb42d2af427b33622a8db10ee88a856dc3a76ddb4d6cd",
+  "pins" : [
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-syntax.git",
+      "state" : {
+        "revision" : "64889f0c732f210a935a0ad7cda38f77f876262d",
+        "version" : "509.1.1"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Package.swift
+++ b/Package.swift
@@ -38,7 +38,7 @@ let package = Package(
             dependencies: ["Compose"]
         ),
         .testTarget(
-            name: "MacroTests",
+            name: "ComposeMacroTests",
             dependencies: [
                 "ComposeMacro",
                 .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax"),

--- a/Sources/ComposeMacro/ComposableObjectMacro.swift
+++ b/Sources/ComposeMacro/ComposableObjectMacro.swift
@@ -68,7 +68,7 @@ private extension VariableDeclSyntax {
     }
     
     var isPrivateProperty: Bool {
-        modifier?.name.text == "private"
+        modifier?.name.text == "private" && modifier?.detail?.detail.text != "set"
     }
 }
 

--- a/Tests/ComposeMacroTests/ComposeMacroTests.swift
+++ b/Tests/ComposeMacroTests/ComposeMacroTests.swift
@@ -1,5 +1,5 @@
 //
-//  MacroTests.swift
+//  ComposeMacroTests.swift
 //
 //
 //  Created by jsilver on 6/2/24.
@@ -14,7 +14,7 @@ let testMacros: [String: Macro.Type] = [
     "ComposableObject": ComposableObjectMacro.self,
 ]
 
-final class MacroTests: XCTestCase {
+final class ComposeMacroTests: XCTestCase {
     // MARK: - Property
     
     // MARK: - Lifecycle
@@ -32,15 +32,21 @@ final class MacroTests: XCTestCase {
             """
             @ComposableObject
             class Environment {
-                var a: Int = 0
-                private var b: Int = 0
+                public var a: Int = 0
+                var b: Int = 0
+                private(set) var c: Int = 0
+                private var d: Int = 0
             }
             """,
             expandedSource: """
             class Environment {
                 @Published
-                var a: Int = 0
-                private var b: Int = 0
+                public var a: Int = 0
+                @Published
+                var b: Int = 0
+                @Published
+                private(set) var c: Int = 0
+                private var d: Int = 0
             }
 
             extension Environment: ObservableObject {


### PR DESCRIPTION
# 📌 Reference
> Add any references to help understand this pull request.


# 🔥 Cause
> If there is a reason, write why the code changes was occurred.


# 📄 Changes
> Write what is changed.
> You can write more detail informations using MD syntax.

### Fixed
- Renamed to `ComposeMacroTest` to avoid duplication of the `MacroTest` target name.
- Fixed `ComposableObject` macro to be applied correctly to access modifiers.
  - Fixed the macro not adding the attribute to the `private(set)` property.

# 🚧 Testing
> Write how to test and results of changes using screenshots, gifs, any others.
